### PR TITLE
Migrate to FDO 23.08 and Node 18.

### DIFF
--- a/com.github.zadam.trilium.yml
+++ b/com.github.zadam.trilium.yml
@@ -1,11 +1,11 @@
 app-id: com.github.zadam.trilium
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.node16
+  - org.freedesktop.Sdk.Extension.node18
 base: org.electronjs.Electron2.BaseApp
-base-version: '21.08'
+base-version: '23.08'
 command: trilium
 separate-locales: false
 finish-args:
@@ -16,7 +16,7 @@ finish-args:
   - --share=network
   - --filesystem=home
 build-options:
-  append-path: /usr/lib/sdk/node16/bin
+  append-path: /usr/lib/sdk/node18/bin
   env:
     NPM_CONFIG_LOGLEVEL: info
 modules:
@@ -26,7 +26,7 @@ modules:
       env:
         XDG_CACHE_HOME: /run/build/trilium/flatpak-node/cache
         npm_config_cache: /run/build/trilium/flatpak-node/npm-cache
-        npm_config_nodedir: /usr/lib/sdk/node16
+        npm_config_nodedir: /usr/lib/sdk/node18
         npm_config_offline: 'true'
         SRC_DIR: dist/trilium-src
     sources:


### PR DESCRIPTION
FDO 21.08 is end-of-life now. There's no Node 16 for FDO 23.08, but Node 18 seems to work fine.